### PR TITLE
Fix workflow permissions for PR commenting

### DIFF
--- a/.github/workflows/integration-manual.yml
+++ b/.github/workflows/integration-manual.yml
@@ -33,6 +33,11 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 env:
   GO_VERSION: "1.21"
 


### PR DESCRIPTION
## Summary
- Add explicit permissions to the manual integration test workflow to enable PR commenting
- Fixes "Resource not accessible by integration" error when workflow attempts to post test results

## Changes
- Added workflow-level permissions:
  - `contents: read` - Required to checkout code
  - `issues: write` - Required to comment on issues
  - `pull-requests: write` - Required to comment on PRs

## Problem
The manual integration test workflow was failing in the test summary job with:
```
RequestError [HttpError]: Resource not accessible by integration
```

This occurred when the workflow tried to post comments on PRs using the GitHub API.

## Solution
By explicitly declaring the required permissions at the workflow level, we grant the necessary access for the GITHUB_TOKEN to interact with issues and pull requests.

## Test Plan
- [ ] Run the manual integration workflow with a PR number
- [ ] Verify the workflow can successfully post comments to the PR
- [ ] Confirm all other workflow steps continue to function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)